### PR TITLE
Updated version check link

### DIFF
--- a/lua/dronesrewrite/main.lua
+++ b/lua/dronesrewrite/main.lua
@@ -168,7 +168,7 @@ end
 if SERVER then
 	hook.Add("Initialize", "dronesrewrite_inithook", function()
 		timer.Simple(0, function()
-			http.Fetch("https://raw.githubusercontent.com/ProfessorBear/Drones-Rewrite/master/version.txt",
+			http.Fetch("https://raw.githubusercontent.com/Ayditor/DronesRewrite/master/version.txt",
 				function(body, len, headers, code)
 					local version = tonumber(body)
 


### PR DESCRIPTION
The old link doesn't work anymore and prints a "New version: 404 not found" in console.